### PR TITLE
Hotfix

### DIFF
--- a/PlanSimple/MVVM/ViewModel/CalendarDisplayViewModel.cs
+++ b/PlanSimple/MVVM/ViewModel/CalendarDisplayViewModel.cs
@@ -12,8 +12,8 @@ namespace PlanSimple.MVVM.ViewModel
 {
 
     public class CalendarDisplayViewModel : BaseViewModel
-    {       
-        
+    {
+        public static DateTime DisplayedWeek = DateTime.Now;
         public BindingList<WeekDayModel> Week { get; set; } = new();
         public string? CurrentMonth { get => CalendarHelper.GetMonthName(Week.FirstOrDefault()?.Date); }
         public BindingList<ToDoListDisplayModel> Days { get; set; } = new();
@@ -69,6 +69,8 @@ namespace PlanSimple.MVVM.ViewModel
             {
                 Week[i].Date = Week[i].Date.AddDays(days);
             }
+
+            DisplayedWeek = DisplayedWeek.AddDays(days);
             Week.ResetBindings();
             GetNotesForWeek();
             OnPropertyChanged(nameof(CurrentMonth));
@@ -76,7 +78,7 @@ namespace PlanSimple.MVVM.ViewModel
 
         private void SetWeekDays()
         {
-            var currentDay = DateTime.Now;
+            var currentDay = DisplayedWeek;
 
             var week = CalendarHelper.GetWeek(currentDay)
                 .Select(x => new WeekDayModel { Date = DateOnly.FromDateTime(x) })

--- a/PlanSimple/MainWindow.xaml
+++ b/PlanSimple/MainWindow.xaml
@@ -103,10 +103,10 @@
                 Background="{DynamicResource Background-3}">
                 
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="60"/>
-                    <RowDefinition Height="60"/>
+                    <RowDefinition Height="82"/>
+                    <RowDefinition Height="82"/>
                     <RowDefinition Height="*"/>
-                    <RowDefinition Height="60"/>
+                    <RowDefinition Height="82"/>
                 </Grid.RowDefinitions>
                 
                 <controls:NavigationButtonWithIcon Grid.Row="0" 


### PR DESCRIPTION
Fix: Navigation buttons having different height than Calendar view's week information
Fix: Calendar view displayed week resetting back to current week on every view change